### PR TITLE
fix: Fix word-break of badge

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -40,6 +40,7 @@ const BadgeUI = styled.div<
       ? `inset 0 0 0 1px ${borderColor ?? `color-mix(in oklab, ${fgColor ?? theme.color.dark} 10%, transparent 90%)`}`
       : `inset 0 0 0 1px ${borderColor ?? 'none'}`,
   color: fgColor ?? theme.color.dark,
+  wordBreak: 'normal',
 }))
 
 const TooltipUI = styled.div(({ theme }) => ({


### PR DESCRIPTION
Closes #53.

For narrow sidebar widths the default storybook `word-break` setting can cause ugly word breaks:

![Screenshot 2025-03-07 at 09 56 31](https://github.com/user-attachments/assets/788005f9-57de-458e-a474-d5843308e9b1)

This PR fixes this issue by explicitly overwriting the break-word property:
![Screenshot 2025-03-07 at 09 58 46](https://github.com/user-attachments/assets/ef79362b-5fde-43be-b726-b38ef532ce2b)
