### PR TITLE
docs: fixing incorrect sidebar config

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ addons.setConfig({
         tooltip: 'This component can catch flies!',
       },
       display: {
-        sidebar: ['component'],
+        sidebar: [{
+          type: 'component'
+        }],
         toolbar: false,
         mdx: true,
       },
@@ -244,7 +246,7 @@ A condition for the sidebar takes two properties:
 | Property        | Description                                                                                          | Type     | Example value |
 | --------------- | ---------------------------------------------------------------------------------------------------- | -------- | ------------- |
 | `type`          | The type of entry to match                                                                           | `string` | `'docs'`      |
-| `skipInherited` | Whether to skip showing the badge if a parent entry in the UI already shows a badge for the same tag | `string` | `true`        |
+| `skipInherited` | Whether to skip showing the badge if a parent entry in the UI already shows a badge for the same tag | `boolean` | `true`        |
 
 Using the default config for `display` is heavily recommended. It is defined as follows:
 ```ts


### PR DESCRIPTION
In the example, I skipped the `skipInherited` prop. Which I can should be define as optional.
Can easily make that change too.