### PR TITLE
fix(Badge): Remove empty state ø sign from MDXBadges

### DIFF
--- a/src/components/MDXBadges.tsx
+++ b/src/components/MDXBadges.tsx
@@ -61,6 +61,6 @@ export const MDXBadges: FC<MDXBadgesProps> = (props) => {
       ))}
     </BadgeContainer>
   ) : (
-    'ø'
+    ''
   )
 }


### PR DESCRIPTION
Closes #116 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.3--canary.117.18585864999.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-tag-badges@2.0.3--canary.117.18585864999.0
  # or 
  yarn add storybook-addon-tag-badges@2.0.3--canary.117.18585864999.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
