### PR TITLE
fix: Add type decls for manager helpers

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -26,13 +26,13 @@ export default defineConfig(async () => {
 
   // manager entries are entries meant to be loaded into the manager UI
   // they'll have manager-specific packages externalized and they won't be usable in node
-  // they won't have types generated for them as they're usually loaded automatically by Storybook
   if (managerEntries.length) {
     configs.push({
       ...commonConfig,
       entry: managerEntries,
       platform: 'browser',
       target: 'esnext',
+      dts: true,
     })
   }
 


### PR DESCRIPTION
Closes #124 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.0.2--canary.125.18909659504.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-tag-badges@3.0.2--canary.125.18909659504.0
  # or 
  yarn add storybook-addon-tag-badges@3.0.2--canary.125.18909659504.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
