### PR TITLE
Fix inherited badge resolution in composed Storybooks

### DIFF
--- a/src/__tests__/useBadgesToDisplay.spec.ts
+++ b/src/__tests__/useBadgesToDisplay.spec.ts
@@ -7,9 +7,12 @@ import { defaultConfig } from '../defaultConfig'
 
 vi.mock('storybook/manager-api', () => ({
   useStorybookApi: vi.fn(() => ({
-    resolveStory: vi.fn().mockImplementation((id) => {
+    resolveStory: vi.fn().mockImplementation((id, refId) => {
       if (id === 'mock-component') {
         return { type: 'component', tags: ['test1', 'test2', 'test3'] }
+      }
+      if (id === 'mock-composed-component' && refId === 'child-ref') {
+        return { type: 'component', tags: ['test2'] }
       }
       return { type: 'component', tags: [] }
     }),
@@ -360,6 +363,21 @@ describe('useBadgesToDisplay', () => {
           context: 'sidebar',
           parameters,
           parent: 'mock-component',
+          tags: ['test2'],
+          type: 'story',
+        }),
+      )
+
+      expect(result.current).toHaveLength(0)
+    })
+
+    it('uses refId when resolving composed parents', () => {
+      const { result } = renderHook(() =>
+        useBadgesToDisplay({
+          context: 'sidebar',
+          parameters,
+          parent: 'mock-composed-component',
+          refId: 'child-ref',
           tags: ['test2'],
           type: 'story',
         }),

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -61,6 +61,7 @@ export const Sidebar: FC<SidebarProps> = ({
     context: 'sidebar',
     parameters,
     parent: item.parent,
+    refId: item.refId,
     tags: item.tags,
     type: item.type,
   })

--- a/src/useBadgesToDisplay.ts
+++ b/src/useBadgesToDisplay.ts
@@ -16,6 +16,7 @@ interface UseBadgesToDisplayOptions {
   context: 'mdx' | 'sidebar' | 'toolbar'
   parameters: TagBadgeParameters
   parent?: string
+  refId?: string
   tags: string[]
   type:
     | API_ComponentEntry['type']
@@ -30,6 +31,7 @@ function _useBadgesToDisplay({
   context,
   parameters,
   parent,
+  refId,
   tags,
   type,
 }: UseBadgesToDisplayOptions & {
@@ -43,7 +45,7 @@ function _useBadgesToDisplay({
   let parentTags: string[] | undefined
   let resolvedParent: API_HashEntry | undefined
   if (api && parent) {
-    resolvedParent = api.resolveStory(parent)
+    resolvedParent = api.resolveStory(parent, refId)
     if (resolvedParent && resolvedParent.type !== 'root') {
       parentTags = resolvedParent.tags
     }
@@ -74,6 +76,7 @@ function _useBadgesToDisplay({
           context,
           parameters,
           parent: resolvedParent.parent,
+          refId,
           tags: parentTags,
           type: resolvedParent.type,
         })
@@ -94,6 +97,7 @@ export function useBadgesToDisplay({
   context,
   parameters,
   parent,
+  refId,
   tags,
   type,
 }: UseBadgesToDisplayOptions): BadgesToDisplay {
@@ -106,9 +110,10 @@ export function useBadgesToDisplay({
         context,
         parameters,
         parent,
+        refId,
         tags,
         type,
       }),
-    [context, parameters, parent, tags, type],
+    [context, parameters, parent, refId, tags, type],
   )
 }

--- a/src/useBadgesToDisplay.ts
+++ b/src/useBadgesToDisplay.ts
@@ -45,6 +45,9 @@ function _useBadgesToDisplay({
   let parentTags: string[] | undefined
   let resolvedParent: API_HashEntry | undefined
   if (api && parent) {
+    // Composed Storybooks need refId so the manager API resolves the parent from
+    // the correct child ref. Standalone instances do not set refId, and leaving
+    // it undefined preserves the existing local resolution behavior.
     resolvedParent = api.resolveStory(parent, refId)
     if (resolvedParent && resolvedParent.type !== 'root') {
       parentTags = resolvedParent.tags


### PR DESCRIPTION
## Summary
Resolve inherited badge lookups against the correct composed Storybook ref so `skipInherited` behaves the same in composed and standalone instances.

## What changed
- pass `refId` through `useBadgesToDisplay` when resolving parent entries
- keep standalone behavior unchanged by leaving `refId` optional
- add a regression test covering composed parent resolution
- document why `refId` is needed at the parent lookup

Fixes #17