### PR TITLE
fix: Drop bare side-effect imports of external modules from dist

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -17,7 +17,11 @@ export default defineConfig(async () => {
   const commonConfig: Options = {
     splitting: true,
     format: ['esm'],
-    treeshake: true,
+    // 'no-external' drops side-effect-only imports of external modules
+    // (e.g. `import 'storybook/internal/channels'`), which Storybook's
+    // Vite builder rewrites into invalid JS in consumer preview builds.
+    // See https://github.com/Sidnioulz/storybook-addon-tag-badges/issues/151
+    treeshake: { preset: 'recommended', moduleSideEffects: 'no-external' },
     clean: false,
     external: ['react', 'react-dom', '@storybook/icons'],
   }


### PR DESCRIPTION
Fixes #151.

## Problem

`dist/manager-helpers.js` contained side-effect-only imports of externalized Storybook modules, left behind by the tsup/rollup treeshake step (currently `import 'storybook/internal/channels'`; 3.0.5 also had `client-logger` and `preview-api`).

When a consumer imports `MDXBadges` from `storybook-addon-tag-badges/manager-helpers` in an MDX file, that file becomes part of their **preview** build. Storybook's Vite builder (`storybook:external-globals-plugin`) rewrites imports of globalized modules into `const` destructuring reading from globals — but for a *bare* import there is nothing to destructure, so it produces invalid JavaScript:

```js
// import 'storybook/internal/channels' becomes:
const __STORYBOOK_MODULE_CHANNELS__;
```

Hence `'const' declarations must be initialized` on Storybook 10.2.6 and `Missing initializer in const declaration` on 10.3.

## Fix

Set rollup's `treeshake.moduleSideEffects` to `'no-external'` in `tsup.config.ts`, so side-effect-only imports of external modules are dropped from the bundles. All remaining imports of globalized modules are named imports, which the builder rewrites into valid destructuring. No entry of the addon relies on side effects of external modules, and the API/output is otherwise unchanged, so this is not a breaking change.

## Verification

For each of Storybook **10.2.6**, **10.3.6**, and **10.5.0-beta.1**, I set up a minimal `@storybook/react-vite` project with a CSF story (tags `['new', 'version:1.2.3']`) and an MDX page importing `MDXBadges` from `storybook-addon-tag-badges/manager-helpers`:

| Storybook | `storybook build` with published 3.1.0 | with this fix (packed tarball) |
| --- | --- | --- |
| 10.2.6 (vite 6) | ❌ `'const' declarations must be initialized` at `import 'storybook/internal/channels'` | ✅ builds |
| 10.3.6 (vite 7) | ❌ same rollup parse error | ✅ builds |
| 10.5.0-beta.1 (vite 7) | ✅ builds (upstream builder now tolerates bare imports) | ✅ builds |

> Note: the issue asked for 10.5.0-beta.2, but the newest published 10.5 prerelease on npm is `10.5.0-beta.1` (the `next` dist-tag), so that's what I tested.

I also smoke-tested each built Storybook in headless Chromium: the docs page renders and `MDXBadges` displays the `New` and `1.2.3` badges (manager ↔ preview channel round-trip works).

Repo checks: `vitest run --project unit` (119 passed), `eslint`, `prettier --check`, and `storybook build` of this repo all pass. The browser-mode story tests couldn't run in my sandbox (pinned Playwright browser build unavailable), but the change only touches bundler config, not runtime source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDnrYwVFFG7ABZcZCXD2Py

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDnrYwVFFG7ABZcZCXD2Py)_